### PR TITLE
Use __invert__ to implement ~Rule()

### DIFF
--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -131,6 +131,9 @@ class Rule:
     def __not__(self):
         return Not(self)
 
+    def __invert__(self):
+        return Not(self)
+
 
 class BinaryCompositeRule(Rule):
     def __init__(self, left, right):
@@ -219,6 +222,9 @@ class Not(Rule):
 
     def check(self, user, instance=None):
         return not self.base.check(user, instance)
+
+    def __invert__(self):
+        return self.base
 
 
 class blanket_rule(Rule):  # noqa: used as a decorator, so should be lowercase


### PR DESCRIPTION
I noticed that `~Attribute(...)` didn't work, because you hadn't implemented `__invert__`. I also made stacking `~` not build up a stack of objects.