### PR TITLE
Added checks for EMPTY and UNIVERSAL in query function

### DIFF
--- a/bridgekeeper/rules.py
+++ b/bridgekeeper/rules.py
@@ -359,7 +359,12 @@ class R(Rule):
             # TODO: check lookups are not being used
             if isinstance(value, Rule):
                 child_q_obj = value.query(user)
-                accumulated_q &= add_prefix(child_q_obj, key)
+                if child_q_obj is EMPTY:
+                    accumulated_q &=Q(pk__in=[])
+                elif child_q_obj is UNIVERSAL:
+                    pass
+                else:
+                    accumulated_q &= add_prefix(child_q_obj, key)
             else:
                 resolved_value = value(user) if callable(value) else value
                 accumulated_q &= Q(**{key: resolved_value})


### PR DESCRIPTION
I'm not sure if blanket rules are meant to be nested in Rs, but I think it would definitely be useful:

```
class MyModel(Model):
    pass


class MyOtherModel(Model):
    parent = models.ForeignKey(MyModel)


@blanket_rule
def is_admin(user):
    # something


perms['myapp.view_mymodel'] = is_admin # and more complex stuff
perms['myapp.view_myothermodel'] = R(parent=perms['myapp.view_mymodel'])
```

This is a minimal example where I just want to set permissions of `MyOtherModel` based on the existing permissions of the referenced model `MyModel`.

This currently leads to
```
  File "[...]/rest_framework/views.py", line 332, in check_permissions
    if not permission.has_permission(request, self):
  File "[...]/bridgekeeper/rest_framework.py", line 161, in has_permission
    return self.get_permission(request, view).is_possible_for(request.user)
  File "[...]/bridgekeeper/rules.py", line 86, in is_possible_for
    return self.query(user) is not EMPTY
  File "[...]/bridgekeeper/rules.py", line 367, in query
    accumulated_q &= add_prefix(child_q_obj, key)
  File "[...]/bridgekeeper/rules.py", line 535, in add_prefix
    for child in q_obj.children
AttributeError: 'Sentinel' object has no attribute 'children'
```

I fixed this by added checks for EMPTY and UNIVERSAL in query function and modify query appropriately. 

Is this correct?