### PR TITLE
DOC: use new R rules instead of Attribute in documentation guides

### DIFF
--- a/docs/guides/permissions.rst
+++ b/docs/guides/permissions.rst
@@ -47,9 +47,7 @@ When you check permissions like this without supplying an instance, Bridgekeeper
 
 As an example of this, let's say that the ``shrubberies.view_shrubbery`` permission was defined to allow staff users access to all shrubberies, and everyone else access to shrubberies in their own branch::
 
-    perms['shrubberies.view_shrubbery'] = is_staff | Attribute(
-        'branch', lambda user: user.profile.branch,
-    )
+    perms['shrubberies.view_shrubbery'] = is_staff | R(branch=lambda user: user.profile.branch)
 
 In this case, the check would return ``True`` for a staff user, since they will always have access to every possible shrubbery. It will return ``False`` for a regular user, even if every shrubbery currently in the database belongs to their branch, because it is possible for a shrubbery to be created that belongs to a different branch, which they would then be blocked from editing.
 
@@ -64,9 +62,7 @@ This check will return ``True`` if and only if the user could possibly have that
 
 As an example of this, let's say that the ``shrubberies.view_shrubbery`` permission was defined to allow only shrubbers to edit shrubberies inside their own branch, using the ``is_shrubber`` rule we created in the :ref:`tutorial-blanket` section of the tutorial and combining it with an :class:`~bridgekeeper.rules.Attribute` check::
 
-    perms['shrubberies.view_shrubbery'] = is_shrubber & Attribute(
-        'branch', lambda user: user.profile.branch,
-    )
+    perms['shrubberies.view_shrubbery'] = is_shrubber & R(branch=lambda user: user.profile.branch)
 
 In this case, the check will return ``False`` for a user with the ``'apprentice'`` role, because only users with the ``'shrubber'`` role can access anything. It will always return ``True`` for a shrubber, however, even if there are no shrubberies belonging to their branch currently in the database, beacuse it is possible for a shrubbery to exist that belongs to their branch, which they would then be allowed to edit.
 

--- a/docs/guides/rules.rst
+++ b/docs/guides/rules.rst
@@ -5,15 +5,14 @@ In Bridgekeeper, a **rule** is something that is given a user and a resource, an
 
 A Bridgekeeper **permission** consists of a name, usually conforming to Django permission name conventions e.g. ``shrubberies.change_shrubbery``, and a rule. Permissions are created by assigning a rule instance to a name in :data:`bridgekeeper.perms`, which acts like a dictionary::
 
-    from bridgekeeper.rules import Attribute, is_staff
+    from bridgekeeper.rules import R, is_staff
     from bridgekeeper import perms
 
     perms['shrubberies.change_shrubbery'] = is_staff
 
 The :mod:`~bridgekeeper.rules` module provides a range of pre-made rule instances as well as rule classes you can instantiate, as shown above. You can also combine rules using the ``&`` (and), ``|`` (or), and ``~`` (not) operators::
 
-    perms['shrubberies.view_shrubbery'] = is_staff | Attribute(
-        'company', lambda user: user.company)
+    perms['shrubberies.view_shrubbery'] = is_staff | R(company=lambda user: user.company)
 
 Finally, if none of the built-in rules do what you want, you can subclass :class:`~bridgekeeper.rules.Rule` yourself and write your own.
 


### PR DESCRIPTION
Hello!

If I understood correctly the code and the changelog, the `R` rule should be used instead of the old `Attribute` one.

Here is a small documentation fix for this.

Thank you for this package!